### PR TITLE
fix Sidebar items color 

### DIFF
--- a/src/Components/Sidebar/Sidebar.jsx
+++ b/src/Components/Sidebar/Sidebar.jsx
@@ -63,7 +63,7 @@ export default function Sidebar(props) {
                     )
                   }}
                 >
-                  <Text align="left" view="link-minor" size="xl">
+                  <Text align="left" view="primary" size="xl">
                     {doc.description}
                   </Text>
                 </div>


### PR DESCRIPTION
Переменная link-minor у нас названа не так, как в wtpr. И вообще её наличие под большим вопросом в нашей теме. Чтобы при переключении темы избежать проблем — заменил на primary. 